### PR TITLE
[tech] Remove prefer-reflect

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,6 @@ module.exports = {
       destructuring: 'all',
       ignoreReadBeforeAssign: false
     }],
-    'prefer-reflect': 'error',
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',
     'prefer-template': 'error',


### PR DESCRIPTION
As https://eslint.org/docs/rules/prefer-reflect states,

> This rule was deprecated in ESLint v3.9.0 and will not be replaced. The original intent of this rule now seems misguided as we have come to understand that Reflect methods are not actually intended to replace the Object counterparts the rule suggests, but rather exist as low-level primitives to be used with proxies in order to replicate the default behavior of various previously existing functionality.